### PR TITLE
Disable Examples check

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,8 @@ The Jared Wilcurt's strict JSDoc ESLint rules for obsessives.
 
 Pairs really well with:
 
-* Sublime Text plugin - [DocBlockr](https://packagecontrol.io/packages/DocBlockr)
-
-You can find other JSDoc plugins for other, slower editors/IDEs. Like:
-
-* VS Codium plugin - [VS DocBlockr](https://github.com/jeremyvii/vs-docblockr) - Not as good as the ST one, but not bad
+* Sublime Text plugin - [DocBlockr](https://packagecontrol.io/packages/DocBlockr) - Best in class
+* VS Codium plugin - [VS DocBlockr](https://github.com/jeremyvii/vs-docblockr) - Not as good as the SublimeText one, but not bad
 * IntelliJ based editors (WebStorm, etc) have a [built in plugin you can enable](https://www.jetbrains.com/help/idea/creating-jsdoc-comments.html#ws_js_preview_jsdoc_comments_rendered_in_the_editor), but it's not open source, it's handled by Jet Brains, and it's almost completely useless. But you can still enable it and try it out. If enough people turn it on, maybe they'll prioritize making it better.
 
 But the point of using ESLint to enforce this is so that you don't have to do editor-specific things. Any team can adopt this approach and each dev can make ESLint work with whatever tools they use.
@@ -36,8 +33,8 @@ But the point of using ESLint to enforce this is so that you don't have to do ed
 
 **See also:**
 
-* [eslint-config-tjw-base](https://github.com/tjw-lint/eslint-config-tjw-base)
-* [eslint-config-tjw-import](https://github.com/tjw-lint/eslint-config-tjw-import)
-* [eslint-config-tjw-jest](https://github.com/tjw-lint/eslint-config-tjw-jest)
-* [eslint-config-tjw-jsdoc](https://github.com/tjw-lint/eslint-config-tjw-jsdoc)
-* [eslint-config-tjw-vue](https://github.com/tjw-lint/eslint-config-tjw-vue)
+* [eslint-config-tjw-base](https://github.com/tjw-lint/eslint-config-tjw-base) - Basic JavaScript Linting
+* [eslint-config-tjw-import](https://github.com/tjw-lint/eslint-config-tjw-import) - Lint import/require statements
+* [eslint-config-tjw-jest](https://github.com/tjw-lint/eslint-config-tjw-jest) - Lint Jest Unit Tests
+* [eslint-config-tjw-jsdoc](https://github.com/tjw-lint/eslint-config-tjw-jsdoc) - Enforce JSDoc comment blocks
+* [eslint-config-tjw-vue](https://github.com/tjw-lint/eslint-config-tjw-vue) - Lint Vue files

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = {
   rules: {
     'jsdoc/check-access': 1,
     'jsdoc/check-alignment': 1,
-    'jsdoc/check-examples': 1,
+    // Turn on after https://github.com/eslint/eslint/issues/14745 resolved
+    'jsdoc/check-examples': 0,
     'jsdoc/check-indentation': 0,
     'jsdoc/check-line-alignment': [
       1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tjw-jsdoc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tjw-jsdoc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "index.js",
   "description": "The Jared Wilcurt's JSDoc Linting rules",
   "author": "The Jared Wilcurt",


### PR DESCRIPTION
I'm disabling this rule so my ESLint 8 repos don't need to override it by default.

Will re-enable once https://github.com/eslint/eslint/issues/14745 is resolved.